### PR TITLE
added baldwin timer functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This bot is an open recreation of an already existing flight rising info bot for
   - `.lookup <dragon id>` Parses and prints info about a particular dragon (example shown below)  
   - `.work`/`.shout` + `[@ mention]` Makes the bot shout "GET BACK TO WORK" if a user is mentioned it will tell that user to get back to work.
   - `.exalt <@ mention>` Pretends to exalt the user mentioned with a random amount of treasure given.
+  - `.transmute` PMs user with reminder after 30 minutes.
+  - `.brew <#h#m>` PMs user with reminder after user-defined amount of time.
 
 # Todo
 

--- a/baldwin.py
+++ b/baldwin.py
@@ -1,0 +1,46 @@
+import discord
+from discord.ext import commands
+import asyncio
+import re
+
+class Baldwin:
+    """double, double, toil and trouble; fire burn and cauldron bubble."""
+
+    timeRe = re.compile(r'(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?')
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(pass_context = True)
+    async def brew(self, context, time):
+        """Given a time in NhNm format, alerts user when that amount of time has passed."""
+        duration = self.parse_duration(time)
+        self.bot.loop.create_task(self.reminder(
+            duration * 60,
+            context.message.author,
+            "YOUR BALDWIN BREW IS DONE. NOW, GET BACK TO WORK."))
+        await self.bot.say("I'LL REMIND YOU ABOUT YOUR BREW IN {0} MINUTES.".format(duration))
+
+    @commands.command(pass_context = True)
+    async def transmute(self, context):
+        """Alerts user after 30 minutes."""
+        self.bot.loop.create_task(self.reminder(
+            30 * 60,
+            context.message.author,
+            "YOUR TRANSMUTATION IS DONE. IS THIS SUPPOSED TO BE COFFEE?"))
+        await self.bot.say("I'LL REMIND YOU ABOUT YOUR BREW IN 30 MINUTES.")
+
+    async def reminder(self, duration, user, message):
+        await asyncio.sleep(duration)
+        await self.bot.send_message(user, message)
+
+    def parse_duration(self, time):
+        match = self.timeRe.match(time)
+        if match is None:
+            return 0
+        hours = match.group('hours') or 0
+        minutes = match.group('minutes') or 0
+        return int(hours) * 60 + int(minutes)
+
+def setup(bot):
+    bot.add_cog(Baldwin(bot))

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,5 @@
 import discord
+from discord.ext import commands
 import asyncio
 import json
 import requests
@@ -8,7 +9,10 @@ import time
 import random
 import csv
 
-client = discord.Client()
+# using the commands.Bot() structure for its built-in command functionality.
+client = commands.Bot(command_prefix = "!")
+# contains !brew and !transmute
+client.load_extension('baldwin')
 
 baseurl = "http://flightrising.com"
 commandChar = "!"
@@ -233,6 +237,9 @@ async def on_message(message):
             
 
             await client.send_message(message.channel, None, embed=embed)
+    # this hook will always fire to process commands, at the end of everything else.
+    # if commands overlap with ones that had been defined beforehand, you'll get double messages.
+    await client.process_commands(message)
             
 creds = json.load(open("creds.json","r"))
 


### PR DESCRIPTION
i wrote this pretty fast and cannibalized parts of it from code i'd already written; feel free to adapt it to your own purposes! docstrings and documentation are kind of bad, sorry.

tl;dr of changes -
- used `commands.Bot()` framework instead of `discord.Client()`. this shouldn't interfere with any of the previously-defined commands, but should make things easier to maintain and organize. everything else in my code is in `baldwin.py`, pretty much.
-  added `!transmute` and `!brew` options, which should replicate the functionality previously available in echo. `!transmute` simply PMs the user after 30m, while `!brew` takes in a time argument (i.e. 1h30m, 2h, 45m) and PMs the user after that amount of time.

feel free to poke me on discord or here if you have any questions or concerns! and feel free to change whatever you want in this, haha. a lot of my strings especially are just random things that popped into my very sleep-deprived head.

i've tested this code on my own, but not super extensively.